### PR TITLE
- bugfix inf battlegroups

### DIFF
--- a/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
+++ b/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
@@ -38,8 +38,11 @@ if !(_spawn_marker isEqualTo "") then {
             };
             [selectRandom _infClasses, markerPos _spawn_marker, _grp] call KPLIB_fnc_createManagedUnit;
         };
-        [_grp] spawn battlegroup_ai;
+        // [_grp] spawn battlegroup_ai;
         _bg_groups pushBack _grp;
+        {
+           [_x] spawn battlegroup_ai;
+        } forEach _bg_groups;
     } else {
         private _vehicle_pool = [KPLIB_o_battleGrpVehicles, KPLIB_o_battleGrpVehiclesLight] select (KPLIB_enemyReadiness < 50);
 


### PR DESCRIPTION
Fix. Only one of the created infantry battlegroups moved towards designated target.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? |  no <!-- don't forget to update CHANGELOG.md file --> |
| Needs wipe? | no <!-- set to yes if save needs to be wiped to use new feature --> |

### Description: When infantry only counter attack battlegroups are spawned, only one of the created battlegroups are charging towards their designated target. This patch should change this and let all spawned battlegroups move towards target.

<!--
Write short description about this pull request
by replacing this comment block
-->

### Content:
- [ ] Content part

<!--
Add things which are part of this pull request as checkboxes
to show if it's already finished and already part of the pull request.
-->

### Successfully tested on:
- [ ] Local MP
- [ ] Dedicated MP

<!--
As soon as you've tested your feature on the listed environment you can check the checkbox.
It has to work without any issues and errors in your own tests.
-->
